### PR TITLE
test: Use syphar/restore-virtualenv@v1 to cache the python venv

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         python-version:
             - "3.10"
-            - "3.11"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -49,23 +48,15 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - python-version: "3.11"
-            pytest-flags: ""
-            codecov: true
-            platform: "ubuntu-latest"
           - python-version: "3.10"
             pytest-flags: ""
-            codecov: false
-            platform: "ubuntu-latest"
-          - python-version: "3.11"
-            pytest-flags: "--only-integration"
             codecov: false
             platform: "ubuntu-latest"
           - python-version: "3.10"
             pytest-flags: "--only-integration"
             codecov: false
             platform: "ubuntu-latest"
-          - python-version: "3.11"
+          - python-version: "3.10"
             pytest-flags: "--only-slow-integration"
             codecov: false
             platform: "ubuntu-latest"
@@ -95,6 +86,7 @@ jobs:
       run: |
         PYTHONPATH=$PWD/src \
         pytest tests \
+        --reverse \
         --cov-report=xml \
         --cov-branch \
         --cov jdrones \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,36 +10,10 @@ on:
     workflow_dispatch:
 
 jobs:
-  cache-deps:
-    name: Cache dependencies
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-            - "3.10"
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          cache: "pip"
-          python-version: ${{ matrix.python-version }}
-          cache-dependency-path: |
-            **/requirements*.txt
-
-      - name: Install requirements
-        run: |
-          pip install wheel
-          pip install -r requirements.txt
 
   run-tests:
     name: Run tests
     runs-on: ${{ matrix.platform }}
-    needs: cache-deps
     defaults:
       run:
         shell: bash -l {0}
@@ -78,7 +52,11 @@ jobs:
     - name: Install wheel
       run: pip install wheel
 
+    - uses: syphar/restore-virtualenv@v1
+      id: cache-virtualenv
+
     - name: Install dependencies
+      if: steps.cache-virtualenv.outputs.cache-hit != 'true'
       run: |
         pip install -r requirements.txt -r tests/requirements.txt
 
@@ -86,7 +64,6 @@ jobs:
       run: |
         PYTHONPATH=$PWD/src \
         pytest tests \
-        --reverse \
         --cov-report=xml \
         --cov-branch \
         --cov jdrones \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provide a [gymnasium] style interface using a physics simulation engine ([pybull
 Create the local development environment:
 
 ```bash
-conda create --name jdrones
+conda create --name jdrones python=3.10
 conda activate jdrones
 pip install -r requirements.txt -r tests/requirements.txt
 ```

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest-cov
 pytest-extra-markers
 pytest-mock
 pytest-xdist
+pytest-reverse

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,3 @@ pytest-cov
 pytest-extra-markers
 pytest-mock
 pytest-xdist
-pytest-reverse


### PR DESCRIPTION
This has saved around 2 mins per CI run:  https://github.com/iwishiwasaneagle/jdrones/actions/runs/4386071787/usage