### PR TITLE
fix: Position drones would crash if target position was the same as current position

### DIFF
--- a/src/jdrones/envs/position.py
+++ b/src/jdrones/envs/position.py
@@ -154,12 +154,21 @@ class PolynomialPositionBaseDronEnv(BasePositionDroneEnv):
         action_as_state = State()
         action_as_state.pos = action
 
+        term, trunc, info = False, False, {}
+        if np.allclose(action, self.env.state.pos):
+            # Avoid a singularity since the trajectory is scaled with distance
+            term = True
+            traj = None
+        else:
+            traj = self.calc_traj(
+                self.env.state, action_as_state, self.model.max_vel_ms
+            )
+
         observations = collections.deque()
-        traj = self.calc_traj(self.env.state, action_as_state, self.model.max_vel_ms)
+        observations.append(self.env.state.copy())
 
         u: State = action_as_state.copy()
 
-        term, trunc, info = False, False, {}
         counter = itertools.count(-1)
         while not (term or trunc):
             t = next(counter) * self.dt

--- a/tests/envs/position/test_fifth_order.py
+++ b/tests/envs/position/test_fifth_order.py
@@ -1,0 +1,18 @@
+#  Copyright 2023 Jan-Hendrik Ewers
+#  SPDX-License-Identifier: GPL-3.0-only
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("pos", [(-10, -10, 2)], indirect=True)
+def test_fifth_order_same_start_and_tgt(pos, state, fifthorderpolypositiondroneenv):
+    """
+    Expect the drone to instantly exit with term = True since the target and current
+    position are the same.
+    """
+    obs, _, term, trunc, _ = fifthorderpolypositiondroneenv.step(pos)
+
+    assert term
+    assert not trunc
+    assert len(obs) == 1
+    assert np.allclose(state, obs[0])

--- a/tests/envs/position/test_first_order.py
+++ b/tests/envs/position/test_first_order.py
@@ -1,0 +1,18 @@
+#  Copyright 2023 Jan-Hendrik Ewers
+#  SPDX-License-Identifier: GPL-3.0-only
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("pos", [(-10, -10, 2)], indirect=True)
+def test_first_order_same_start_and_tgt(pos, state, firstorderploypositiondroneenv):
+    """
+    Expect the drone to instantly exit with term = True since the target and current
+    position are the same.
+    """
+    obs, _, term, trunc, _ = firstorderploypositiondroneenv.step(pos)
+
+    assert term
+    assert not trunc
+    assert len(obs) == 1
+    assert np.allclose(state, obs[0])


### PR DESCRIPTION
Now exit early by using an np.allclose check.