### PR TITLE
fix: Skip CI jobs/steps that interact with outside resources if triggered by bot

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload code test coverage report
       uses: codecov/codecov-action@v3.1.1
-      if: ${{ (github.actor != 'dependabot[bot]') && ( matrix.codecov ) && ( !env.ACT ) }}
+      if: ${{ ! contains(github.actor, '[bot]') && ( matrix.codecov ) && ( !env.ACT ) }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml,./coverage.info
@@ -127,6 +127,7 @@ jobs:
 
   docstr-cov:
     runs-on: ubuntu-latest
+    if: ${{ ! contains(github.actor, '[bot]') }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Checks if [bot] is within the username which is fairly accurate way of checking if the triggering actor is a bot